### PR TITLE
Fix links

### DIFF
--- a/talks/dotpy-2020-ow.md
+++ b/talks/dotpy-2020-ow.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title

--- a/talks/dotpy-2020-pip-pypi.md
+++ b/talks/dotpy-2020-pip-pypi.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title

--- a/talks/dotpy-2020-pypi-lightning.md
+++ b/talks/dotpy-2020-pypi-lightning.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title

--- a/talks/ghc-2020-asmr.md
+++ b/talks/ghc-2020-asmr.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title

--- a/talks/pycascades-2020-a-whole-new-world.md
+++ b/talks/pycascades-2020-a-whole-new-world.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title

--- a/talks/pycon-2020-learning-python-as-js-dev.md
+++ b/talks/pycon-2020-learning-python-as-js-dev.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title

--- a/talks/pycon-2020-ow.md
+++ b/talks/pycon-2020-ow.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title
@@ -45,7 +44,7 @@ PyCon pivoted to a virtual conference, so it was uploaded as a pre-recorded YT t
 
 [Slides](https://speakerdeck.com/kimadeline/pycon-us-2020-decoding-bias-and-narrative-in-competitive-video-games-broadcasts-with-video-analysis)
 
-[GitHub repo](<(https://github.com/kimadeline/overwatch-ocr)>)
+[GitHub repo](https://github.com/kimadeline/overwatch-ocr)
 
 [⬆️ Back to top](#title)
 

--- a/talks/pycon-2020-pypi-poster.md
+++ b/talks/pycon-2020-pypi-poster.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title

--- a/talks/pyladies-2020-career-advice-younger-self.md
+++ b/talks/pyladies-2020-career-advice-younger-self.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title

--- a/template.md
+++ b/template.md
@@ -4,7 +4,6 @@
 - [Artifacts](#artifacts)
 - [Abstract](#abstract)
 - [Detailed description](#detailed-description)
-- [Reasons for this talk](#reasons-for-this-talk)
 - [Notes](#notes)
 
 # Title


### PR DESCRIPTION
- Fix GH repo link for PyCon OW
- Removed unused `reason-for-this-talk` top link from template + all talks